### PR TITLE
switch args to the other side of the jar

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,4 +13,4 @@ RUN mkdir -p $HYSTRIX_DASHBOARD_HOME && \
 
 WORKDIR $HYSTRIX_DASHBOARD_HOME
 EXPOSE 7979
-ENTRYPOINT exec java -jar $JVM_ARGS standalone-hystrix-dashboard-$STANDALONE_HYSTRIX_VERSION-all.jar
+ENTRYPOINT exec java $JVM_OPTS -jar standalone-hystrix-dashboard-$STANDALONE_HYSTRIX_VERSION-all.jar $JVM_ARGS


### PR DESCRIPTION
I think the JVM_ARGS were placed incorrectly . I propose this change to make it work.
For reference my workaround in the docker-compose was this
I needed to use the java args because vertx was failing to resolve the docker host names
```
hystrix-dasboard:
    image: kennedyoliveira/hystrix-dashboard:1.5.6
    ports:
    - "7979:7979"
    stdin_open: true
    entrypoint: ["java", "-Dvertx.disableDnsResolver=true", "-jar", "/opt/standalone-hystrix-dashboard/standalone-hystrix-dashboard-1.5.6-all.jar"]
```